### PR TITLE
ViewResult-related fixes for decorated media type formatters

### DIFF
--- a/src/WebApiContrib.Formatting.Html/WebApiContrib.Formatting.Html.cs
+++ b/src/WebApiContrib.Formatting.Html/WebApiContrib.Formatting.Html.cs
@@ -415,10 +415,11 @@ namespace WebApiContrib.Formatting.Html
         /// <returns>The <see cref="HttpResponseMessage"/> representing the view data.</returns>
         public Task<HttpResponseMessage> ExecuteAsync(CancellationToken cancellationToken)
         {
-            var config = RequestMessage.GetConfiguration();
-            var response = RequestMessage.CreateResponse(HttpStatusCode.OK, this, Formatting.Extensions.GetHtmlFormatter(config.Formatters));
+            var response = RequestMessage.CreateResponse(HttpStatusCode.OK, this, TextHtmlMediaType);
             return Task.FromResult(response);
         }
+
+        private static readonly MediaTypeHeaderValue TextHtmlMediaType = new MediaTypeHeaderValue("text/html");
     }
 
     /// <summary>

--- a/src/WebApiContrib.Formatting.Html/WebApiContrib.Formatting.Html.cs
+++ b/src/WebApiContrib.Formatting.Html/WebApiContrib.Formatting.Html.cs
@@ -339,7 +339,10 @@ namespace WebApiContrib.Formatting.Html
             /// <returns>The HtmlMediaTypeFormatter registered to handle requests for HTML.</returns>
             public static MediaTypeFormatter GetHtmlFormatter(this MediaTypeFormatterCollection formatters)
             {
-                return formatters.OfType<Formatting.HtmlMediaTypeViewFormatter>().SingleOrDefault();
+                return formatters
+                    .Select(formatter => System.Web.Http.Services.Decorator.GetInner<MediaTypeFormatter>(formatter))
+                    .OfType<Formatting.HtmlMediaTypeViewFormatter>()
+                    .SingleOrDefault();
             }
         }
     }


### PR DESCRIPTION
Sometimes, the media type formatters are decorated, for example when tracing is enabled, the Web API infrastructure decorates most of the services with "tracers". In case of WebApiContrib.Formatting.Html, it causes ViewResult to err-out with ArgumentNullException due to its inability to locate the correct formatter via MediaTypeFormatterCollection.GetHtmlFormatter extension method (since the contained types are actually *MediaTypeFormatterTracer decorators and OfType<...> check doesn't work).
To counter this, I fixed the GetHtmlFormatter by undecorating the media type formatters before performing the type check. Of course, the better solution would be to create a custom tracer decorator that is properly derived from decorated class (not unlike JsonMediaTypeFormatterTracer), but that would entail a large rewrite. 
The resulting change is, of course, slower than the original, so I decided to investigate its usage and removed it from a "hot" path of ViewResult.ExecuteAsync, leaving formatter selection to the Web API infrastructure using a hard-coded media type of text/html. Since there is not content negotiation support in ViewResult, I consider this change non-breaking and performance is at least the same.
